### PR TITLE
Frontend/SergioBateca/e-commerce: including results numbers of filtering products

### DIFF
--- a/frontend/e-commerce/src/components/ResultInfoBar/ResultPreview/index.jsx
+++ b/frontend/e-commerce/src/components/ResultInfoBar/ResultPreview/index.jsx
@@ -1,15 +1,18 @@
-import { useContext } from 'react'
-import { SearchContext } from '../../../contexts/SearchContext'
-import './ResultPreview.css'
+import { useContext } from "react";
+import { SearchContext } from "../../../contexts/SearchContext";
+import "./ResultPreview.css";
 
-function ResultPreview () {
-    const { searchValue } = useContext(SearchContext)
-        return (
-        <div className='ResultPreviewContainer'>
-            <h3>1-16 of over 4000 results for </h3>
-            <h3 className='SearchWord'>{searchValue}</h3>
-        </div>
-    )
+function ResultPreview() {
+  const { searchValue, searchedProducts } = useContext(SearchContext);
+  return (
+    <div className="ResultPreviewContainer">
+      <h3>
+        1-{searchedProducts.length} of over {searchedProducts.length} results
+        for{" "}
+      </h3>
+      <h3 className="SearchWord">{searchValue}</h3>
+    </div>
+  );
 }
 
-export { ResultPreview }
+export { ResultPreview };


### PR DESCRIPTION
This pull request wants to fix the result section to show the right number of filtered products.
![image](https://github.com/sbateca/ioet-u-junior/assets/19413564/d6e51d07-d10f-425f-b78a-08082fd5f9db)
